### PR TITLE
fix (Environment): multiple environments

### DIFF
--- a/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/SpringPropertiesParser.java
+++ b/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/SpringPropertiesParser.java
@@ -26,6 +26,7 @@ class SpringPropertiesParser extends DefaultPropertiesParser {
     // Members
 
     @Autowired
+    @Qualifier("environment")
     private PropertyResolver propertyResolver;
 
     // Overridden


### PR DESCRIPTION
Fix multiple environments when used with dubbo framework causing boot failure. 
the dubbo class org.apache.dubbo.spring.boot.autoconfigure.DubboRelaxedBinding2AutoConfiguration#dubboScanBasePackagesPropertyResolver create a PropertyResolver causing boot failure.